### PR TITLE
Add a clobber for EventEmitter

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -13,7 +13,9 @@
     <clobbers target="chrome.cast" />
   </js-module>
 
-  <js-module src="EventEmitter.js" name="EventEmitter"></js-module>
+  <js-module src="EventEmitter.js" name="EventEmitter">
+    <clobbers target="EventEmitter" />
+  </js-module>
 
   <js-module src="tests/tests.js" name="tests"></js-module>
 


### PR DESCRIPTION
Required to fix load failures with Cordova 7+.