### PR TITLE
removed unecessary require for EventEmitter

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -1,5 +1,3 @@
-var EventEmitter = require('acidhax.cordova.chromecast.EventEmitter');
-
 var chrome = {};
 chrome.cast = {
 	


### PR DESCRIPTION
This removes the old require for EventEmitter. This is mitigated with the clobbers added for this given javascript module.