### PR TITLE
Move EventEmitter to require method again

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -1,3 +1,5 @@
+var EventEmitter = require('cordova-plugin-chromecast.EventEmitter');
+
 var chrome = {};
 chrome.cast = {
 	

--- a/plugin.xml
+++ b/plugin.xml
@@ -13,9 +13,7 @@
     <clobbers target="chrome.cast" />
   </js-module>
 
-  <js-module src="EventEmitter.js" name="EventEmitter">
-    <clobbers target="EventEmitter" />
-  </js-module>
+  <js-module src="EventEmitter.js" name="EventEmitter"></js-module>
 
   <js-module src="tests/tests.js" name="tests"></js-module>
 


### PR DESCRIPTION
It looks like @vitorsemeano was correct. I found a plugin [here](https://github.com/mapsplugin/cordova-plugin-googlemaps/blob/master/src/browser/PluginGeocoder.js#L3) that uses the method he suggested. My method won't work since cordova isn't initialized completely when the plugins are loading.