### PR TITLE
Fix chromecast playback sometimes not triggering the now-playing state

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -491,6 +491,8 @@ chrome.cast.initialize = function (apiConfig, successCallback, errorCallback) {
 			_routeRefreshInterval = setInterval(function() {
 				execute('emitAllRoutes');
 			}, 15000);
+			
+			setTimeout(function() { execute('emitAllRoutes'); }, 2000);
 
 		} else {
 			handleError(err, errorCallback);

--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -491,8 +491,6 @@ chrome.cast.initialize = function (apiConfig, successCallback, errorCallback) {
 			_routeRefreshInterval = setInterval(function() {
 				execute('emitAllRoutes');
 			}, 15000);
-			
-			setTimeout(function() { execute('emitAllRoutes'); }, 2000);
 
 		} else {
 			handleError(err, errorCallback);

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -760,7 +760,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 
 	@Override
 	public void onMessage(ChromecastSession session, String namespace, String message) {
-		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() +"', '" + namespace + "', '" + message  + "')");
+		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() +"', '" + namespace + "', '" + message.replace("\\", "\\\\")  + "')");
 	}
 
 	//Change all @deprecated this.webView.sendJavascript(String) to this local function sendJavascript(String)

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -609,9 +609,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 				List<RouteInfo> routeList = mMediaRouter.getRoutes();
 
 				for (RouteInfo route : routeList) {
-					if (!route.getName().equals("Phone") && route.getId().indexOf("Cast") > -1) {
-						sendJavascript("chrome.cast._.routeAdded(" + routeToJSON(route) + ")");
-					}
+					onRouteAdded(mMediaRouter, route);
 				}
 			}
 		});

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -609,7 +609,9 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 				List<RouteInfo> routeList = mMediaRouter.getRoutes();
 
 				for (RouteInfo route : routeList) {
-					onRouteAdded(mMediaRouter, route);
+					if (!route.getName().equals("Phone") && route.getId().indexOf("Cast") > -1) {
+						sendJavascript("chrome.cast._.routeAdded(" + routeToJSON(route) + ")");
+					}
 				}
 			}
 		});


### PR DESCRIPTION
Apparently the json messages from the cast api contain the path to subtitle files with unescaped backslashes. Those will now be escaped and the json can then be parsed without errors.