### PR TITLE
Fix now playing state sometimes not working in the web ui when playing to chromecast.

### DIFF
--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -762,7 +762,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 
 	@Override
 	public void onMessage(ChromecastSession session, String namespace, String message) {
-		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() +"', '" + namespace + "', '" + message  + "')");
+		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() +"', '" + namespace + "', '" + message.replace("\\", "\\\\") + "')");
 	}
 
 	//Change all @deprecated this.webView.sendJavascript(String) to this local function sendJavascript(String)


### PR DESCRIPTION
Apparently the json messages from the cast api contain the path to subtitle files with unescaped backslashes. Those will now be escaped and the json can then be parsed without errors.
I checked http://www.json.org and the backslash is the only relevant character here, the other one would be double quotes but those will probably not be part of a filename I guess. 
The real solution would be to find out why the cast api returns invalid json and see if that can be fixed, but I haven't been able to google anything about that.