### PR TITLE
Fix getting device (receiver) volume when connecting a new session

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -524,7 +524,7 @@ chrome.cast.requestSession = function (successCallback, errorCallback, opt_sessi
 			var appId = obj.appId;
 			var displayName = obj.displayName;
 			var appImages = obj.appImages || [];
-			var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.volume || null);
+			var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.receiver.volume || null);
 
 			var session = _sessions[sessionId] = new chrome.cast.Session(sessionId, appId, displayName, appImages, receiver);
 
@@ -1051,7 +1051,7 @@ function onRouteClick() {
 			var appId = obj.appId;
 			var displayName = obj.displayName;
 			var appImages = obj.appImages || [];
-			var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.volume || null);
+			var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.receiver.volume || null);
 
 			var session = _sessions[sessionId] = new chrome.cast.Session(sessionId, appId, displayName, appImages, receiver);
 
@@ -1145,7 +1145,7 @@ chrome.cast._ = {
 		var appId = obj.appId;
 		var displayName = obj.displayName;
 		var appImages = obj.appImages || [];
-		var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.volume || null);
+		var receiver = new chrome.cast.Receiver(obj.receiver.label, obj.receiver.friendlyName, obj.receiver.capabilities || [], obj.receiver.volume || null);
 
 		var session = _sessions[sessionId] = new chrome.cast.Session(sessionId, appId, displayName, appImages, receiver);
 


### PR DESCRIPTION
The "obj" does not contain the volume directly, rather the contained receiver object.
I don't think the volume is used right now, but would be useful for https://github.com/jellyfin/jellyfin-web/pull/219 for volume-up and volume-down to use the currently set device volume.