### PR TITLE
Upgrade to androidx

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -36,9 +36,9 @@
     </config-file>
 
     <framework src="com.google.android.gms:play-services-cast:16.1.2" />
-    <framework src="com.android.support:appcompat-v7:28.0.0" />
-    <framework src="com.android.support:mediarouter-v7:28.0.0" />
-    <framework src="com.android.support:support-v4:28.0.0" />
+    <framework src="androidx.appcompat:appcompat:1.0.0" />
+    <framework src="androidx.mediarouter:mediarouter:1.0.0" />
+    <framework src="androidx.legacy:legacy-support-v4:1.0.0" />
 
     <source-file src="src/android/Chromecast.java" target-dir="src/acidhax/cordova/chromecast" />
     <source-file src="src/android/ChromecastMediaController.java" target-dir="src/acidhax/cordova/chromecast" />

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -23,9 +23,9 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
-import android.support.v7.media.MediaRouter;
-import android.support.v7.media.MediaRouteSelector;
-import android.support.v7.media.MediaRouter.RouteInfo;
+import androidx.mediarouter.media.MediaRouter;
+import androidx.mediarouter.media.MediaRouteSelector;
+import androidx.mediarouter.media.MediaRouter.RouteInfo;
 import android.util.Log;
 import android.widget.ArrayAdapter;
 

--- a/src/android/ChromecastMediaRouterCallback.java
+++ b/src/android/ChromecastMediaRouterCallback.java
@@ -3,14 +3,14 @@ package acidhax.cordova.chromecast;
 import java.util.ArrayList;
 import java.util.Collection;
 
-import android.support.v7.media.MediaRouter;
-import android.support.v7.media.MediaRouter.RouteInfo;
+import androidx.mediarouter.media.MediaRouter;
+import androidx.mediarouter.media.MediaRouter.RouteInfo;
 
 public class ChromecastMediaRouterCallback extends MediaRouter.Callback {
 	private volatile ArrayList<RouteInfo> routes = new ArrayList<RouteInfo>();
-	
+
 	private Chromecast callback = null;
-	
+
 	public void registerCallbacks(Chromecast instance) {
 		this.callback = instance;
 	}
@@ -39,7 +39,7 @@ public class ChromecastMediaRouterCallback extends MediaRouter.Callback {
 			this.callback.onRouteAdded(router, route);
 		}
 	}
-	
+
 	@Override
 	public void onRouteRemoved(MediaRouter router, RouteInfo route) {
 		routes.remove(route);
@@ -47,14 +47,14 @@ public class ChromecastMediaRouterCallback extends MediaRouter.Callback {
 			this.callback.onRouteRemoved(router, route);
 		}
 	}
-	
+
 	@Override
 	public void onRouteSelected(MediaRouter router, RouteInfo info) {
 		if (this.callback != null) {
 			this.callback.onRouteSelected(router, info);
 		}
 	}
-	
+
 	@Override
 	public void onRouteUnselected(MediaRouter router, RouteInfo info) {
 		if (this.callback != null) {

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -27,7 +27,7 @@ import com.google.android.gms.common.api.Status;
 import com.google.android.gms.common.images.WebImage;
 
 import android.os.Bundle;
-import android.support.v7.media.MediaRouter.RouteInfo;
+import androidx.mediarouter.media.MediaRouter.RouteInfo;
 
 /*
  * All of the Chromecast session specific functions should start here.

--- a/src/android/ChromecastUtilities.java
+++ b/src/android/ChromecastUtilities.java
@@ -1,7 +1,7 @@
 package acidhax.cordova.chromecast;
 
 import android.graphics.Color;
-import android.support.v4.content.ContextCompat;
+import androidx.core.content.ContextCompat;
 
 import com.google.android.gms.cast.MediaInfo;
 import com.google.android.gms.cast.MediaStatus;


### PR DESCRIPTION
This PR upgrades android support libraries to androidx. This needs to be done so the most recent version of exoplayer can be used in jellyfin-android. Also we maintain these dependencies up to date.