### PR TITLE
Fix: Calling error when Cancel is selected (Chromecast Dialog)

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -595,6 +595,9 @@ chrome.cast.requestSession = function (successCallback, errorCallback, opt_sessi
 
 	execute('requestSession', function(err, obj) {
 		if (!err) {
+			if (obj === 'cancel') {
+				return
+			}
 			var sessionId = obj.sessionId;
 			var appId = obj.appId;
 			var displayName = obj.displayName;

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -227,7 +227,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						dialog.dismiss();
-						callbackContext.error("cancel");
+						callbackContext.success("cancel");
 					}
 				});
 


### PR DESCRIPTION
Hi,

Reopen first part of PR #15 

If the user chose "Cancel" option in the "Choose a Chromecast" dialog, an error is produced and could be awful to the developer's player.

In our case, when you tap in Cancel and error is produced in VideoJS player.