### PR TITLE
Review of the new plugin for iOS

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -73,6 +73,8 @@
       <true/>
     </config-file>
 
+    <dependency id="cordova-plugin-add-swift-support" version="2.0.2"/>
+
     <source-file src="src/ios/Chromecast.swift" />
     <source-file src="src/ios/ChromecastSession.swift" />
     <source-file src="src/ios/CastUtilities.swift" />

--- a/src/ios/Chromecast.swift
+++ b/src/ios/Chromecast.swift
@@ -26,6 +26,20 @@ import GoogleCast
     )
   }
 
+  @objc(emitAllRoutes:)
+  func emitAllRoutes(command: CDVInvokedUrlCommand) {
+    // No arguments. It's only implemented to satisfy plugin's JS API.
+
+    let pluginResult = CDVPluginResult(
+        status: CDVCommandStatus_OK
+    )
+
+    self.commandDelegate!.send(
+        pluginResult,
+        callbackId: command.callbackId
+    )
+  }
+
   @objc(initialize:)
   func initialize(command: CDVInvokedUrlCommand) {
     self.devicesAvailable = [GCKDevice]()
@@ -57,6 +71,7 @@ import GoogleCast
     )
   }
 
+  @objc(checkReceiverAvailable:)
   func checkReceiverAvailable() {
     let sessionManager = GCKCastContext.sharedInstance().sessionManager
 


### PR DESCRIPTION
Hi,

In response of @ghenry22 in PR #16. I resolved two items mentioned.
- Add cordova-plugin-add-swift-support to iOS dependencies.
- Implement emitAllRoutes function in Swift. In this case it's a dummy function because the actual behaviour of maintaining updated the available devices is through `GCKDiscoveryManagerListener`.

I would be very happy if I could get some guidelines to improve the code and the tests.