### PR TITLE
Make the cancel event on the cast dialog trigger the error callback

### DIFF
--- a/chrome.cast.js
+++ b/chrome.cast.js
@@ -1,6 +1,6 @@
 /**
- * Portions of this page are modifications based on work created and shared by 
- * Google and used according to terms described in the Creative Commons 3.0 
+ * Portions of this page are modifications based on work created and shared by
+ * Google and used according to terms described in the Creative Commons 3.0
  * Attribution License.
  */
 var EventEmitter = require('cordova-plugin-chromecast.EventEmitter');
@@ -592,9 +592,6 @@ chrome.cast.requestSession = function (successCallback, errorCallback, opt_sessi
 
 	execute('requestSession', function(err, obj) {
 		if (!err) {
-			if (obj === 'cancel') {
-				return
-			}
 			var sessionId = obj.sessionId;
 			var appId = obj.appId;
 			var displayName = obj.displayName;

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -222,7 +222,14 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 					@Override
 					public void onClick(DialogInterface dialog, int which) {
 						dialog.dismiss();
-						callbackContext.success("cancel");
+						callbackContext.error("cancel");
+					}
+				});
+
+				builder.setOnCancelListener(new DialogInterface.OnCancelListener() {
+					@Override
+					public void onCancel(DialogInterface dialog) {
+						callbackContext.error("cancel");
 					}
 				});
 


### PR DESCRIPTION
This reverts https://github.com/jellyfin/cordova-plugin-chromecast/pull/17, which, as discussed here https://github.com/jellyfin/jellyfin-android/issues/176, brings unwanted behaviour.

The previous code allowed the function to not return an error or success under specific conditions (here when canceling the dialog) which breaks any consumer code expecting either an error or a success.

Also, I added the `onCancel` event listener so we get the same behaviour when touching outside the dialog window, i.e. It returns an error and the dialog closes. Before that, it would just close the window and we'd experience the same bug in https://github.com/jellyfin/jellyfin-android/issues/176.