### PR TITLE
Fix duplicate devices and add device name

### DIFF
--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -214,7 +214,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 				ArrayList<SpannableString> seq_tmp1 = new ArrayList<SpannableString>();
 				final ArrayList<Integer> seq_tmp_cnt_final = new ArrayList<Integer>();
 
-				for (int n = 1; n < routeList.size(); n++) {
+				for (int n = 0; n < routeList.size(); n++) {
 					RouteInfo route = routeList.get(n);
 
 					if (isRouteUsable(route)) {


### PR DESCRIPTION
Fixes https://github.com/jellyfin/cordova-plugin-chromecast/issues/32

So, the duplicates were caused by active sessions on the network. By testing for routes with a SESSION_ID, we can filter them out. So no need to take the dialog in the app itself like I previously thought.

Also, I added the device type below a device name. One more thing is when a device is currently casting, we can now see what application is using the device. Just like the "Cast" button in Chrome or like in the Plex and Spotify apps. See screenshots below. (Note: I don't currently have duplicates on this screenshot but we can see the device name).

I also fixed a bug I introduced with the sorting. The previous code relied on the fact that the first route in the list was the default route (aka the actual phone) so it started the for loop on the second index (1). So by adding a sort, it had the side effect of having devices not show up.

These aren't big changes but it still might break some workflow. I tested on two phones and two different network with different cast devices and I'm fairly confident the code is working as intended, but some more testing should probably done before deploying.

Before
![Screenshot_20190906-221133](https://user-images.githubusercontent.com/14063312/64468529-bd1dfc00-d0f3-11e9-9cf8-ae7d8085e42e.png)

After
![Screenshot_20190906-220847](https://user-images.githubusercontent.com/14063312/64468533-c5763700-d0f3-11e9-89a8-254581275185.png)

When another app is casting on a device
![Screenshot_20190906-221844](https://user-images.githubusercontent.com/14063312/64468589-898fa180-d0f4-11e9-9698-08e33957596e.png)

