### PR TITLE
Fix the exception encountered when playing media with single quote character in the metadata

### DIFF
--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -59,6 +59,7 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 	private volatile ChromecastSession currentSession;
 
 	private void log(String s) {
+		s = s.replace("'", "\\'");
 		sendJavascript("console.log('" + s + "');");
 	}
 
@@ -829,8 +830,8 @@ public class Chromecast extends CordovaPlugin implements ChromecastOnMediaUpdate
 	}
 
 	@Override
-	public void onMessage(ChromecastSession session, String namespace, String message) {
-		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() + "', '" + namespace + "', '" + message.replace("\\", "\\\\") + "')");
+	public void onMessage(ChromecastSession session, String namespace, JSONObject message) {
+		sendJavascript("chrome.cast._.onMessage('" + session.getSessionId() + "', '" + namespace + "', " + message.toString() + ")");
 	}
 
 	//Change all @deprecated this.webView.sendJavascript(String) to this local function sendJavascript(String)

--- a/src/android/ChromecastOnSessionUpdatedListener.java
+++ b/src/android/ChromecastOnSessionUpdatedListener.java
@@ -4,5 +4,5 @@ import org.json.JSONObject;
 
 public interface ChromecastOnSessionUpdatedListener {
 	void onSessionUpdated(boolean isAlive, JSONObject properties);
-	void onMessage(ChromecastSession session, String namespace, String message);
+	void onMessage(ChromecastSession session, String namespace, JSONObject message);
 }

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -694,8 +694,15 @@ public class ChromecastSession
 
 	@Override
 	public void onMessageReceived(CastDevice castDevice, String namespace, String message) {
-		if (this.onSessionUpdatedListener != null) {
-			this.onSessionUpdatedListener.onMessage(this, namespace, message);
+		try {
+			JSONObject json = new JSONObject(message);
+
+			if (this.onSessionUpdatedListener != null) {
+				this.onSessionUpdatedListener.onMessage(this, namespace, json);
+			}
+
+		} catch (Exception e) {
+			e.printStackTrace();
 		}
 	}
 }


### PR DESCRIPTION
This fixes https://github.com/jellyfin/cordova-plugin-chromecast/issues/34 and https://github.com/jellyfin/jellyfin-web/issues/440