### PR TITLE
Fix the Android source files

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-chromecast"
-        version="0.1.0">
+        version="0.1.1">
   <engines>
     <engine name="cordova" version=">=3.4.0" />
   </engines>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://phonegap.com/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
         id="cordova-plugin-chromecast"
-        version="0.0.1">
+        version="0.1.0">
   <engines>
     <engine name="cordova" version=">=3.4.0" />
   </engines>
@@ -48,6 +48,7 @@
     <source-file src="src/android/ChromecastOnSessionUpdatedListener.java" target-dir="src/acidhax/cordova/chromecast" />
     <source-file src="src/android/ChromecastException.java" target-dir="src/acidhax/cordova/chromecast" />
     <source-file src="src/android/ChromecastUtilities.java" target-dir="src/acidhax/cordova/chromecast" />
+    <source-file src="src/android/RouteListComparer.java" target-dir="src/acidhax/cordova/chromecast" />
   </platform>
 
   <platform name="ios">

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -16,6 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.Collections;
 
 import com.google.android.gms.cast.CastDevice;
 import com.google.android.gms.cast.CastMediaControlIntent;


### PR DESCRIPTION
Adds the new resource file `RouteListComparer.java` to the plugin config, and imports the missing `java.util.Collections` in `Chromecast.java`.

Increments the version number in `plugin.xml` to reflect these changes.