### PR TITLE
feat: Added setPlaybackRate and tracks

### DIFF
--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -326,7 +326,7 @@ public final class Chromecast extends CordovaPlugin {
      * @param callbackContext called with .success or .error depending on the result
      * @return true for cordova
      */
-    public boolean setMediaPlayBackRate(Double playbackRate, CallbackContext callbackContext) {
+    public boolean setMediaPlayBackRate(String playbackRate, CallbackContext callbackContext) {
         media.setPlayBackRate(playbackRate, callbackContext);
         return true;
     }

--- a/src/android/Chromecast.java
+++ b/src/android/Chromecast.java
@@ -4,6 +4,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.lang.reflect.Type;
 import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
+import android.util.Log;
 
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CallbackContext;
@@ -299,12 +302,12 @@ public final class Chromecast extends CordovaPlugin {
      * @param callbackContext called with .success or .error depending on the result
      * @return true for cordova
      */
-    public boolean loadMedia(String contentId, JSONObject customData, String contentType, Integer duration, String streamType, Boolean autoPlay, Integer currentTime, JSONObject metadata, JSONObject textTrackStyle, final CallbackContext callbackContext) {
-        return this.loadMedia(contentId, customData, contentType, duration, streamType, autoPlay, new Double(currentTime.doubleValue()), metadata, textTrackStyle, callbackContext);
+    public boolean loadMedia(String contentId, JSONObject customData, String contentType, Integer duration, String streamType, Boolean autoPlay, Integer currentTime, JSONObject metadata, JSONObject textTrackStyle, JSONArray tracks, final CallbackContext callbackContext) {
+        return this.loadMedia(contentId, customData, contentType, duration, streamType, autoPlay, new Double(currentTime.doubleValue()), metadata, textTrackStyle, tracks, callbackContext);
     }
 
-    private boolean loadMedia(String contentId, JSONObject customData, String contentType, Integer duration, String streamType, Boolean autoPlay, Double currentTime, JSONObject metadata, JSONObject textTrackStyle, final CallbackContext callbackContext) {
-        this.media.loadMedia(contentId, customData, contentType, duration, streamType, autoPlay, currentTime, metadata, textTrackStyle, callbackContext);
+    private boolean loadMedia(String contentId, JSONObject customData, String contentType, Integer duration, String streamType, Boolean autoPlay, Double currentTime, JSONObject metadata, JSONObject textTrackStyle, JSONArray tracks, final CallbackContext callbackContext) {
+        this.media.loadMedia(contentId, customData, contentType, duration, streamType, autoPlay, currentTime, metadata, textTrackStyle, tracks, callbackContext);
         return true;
     }
 
@@ -315,6 +318,16 @@ public final class Chromecast extends CordovaPlugin {
      */
     public boolean mediaPlay(CallbackContext callbackContext) {
         media.mediaPlay(callbackContext);
+        return true;
+    }
+
+    /**
+     * Play on the current media in the current session.
+     * @param callbackContext called with .success or .error depending on the result
+     * @return true for cordova
+     */
+    public boolean setMediaPlayBackRate(Double playbackRate, CallbackContext callbackContext) {
+        media.setPlayBackRate(playbackRate, callbackContext);
         return true;
     }
 

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -2,6 +2,7 @@ package acidhax.cordova.chromecast;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
 
 import org.apache.cordova.CallbackContext;
 import org.json.JSONArray;
@@ -219,14 +220,14 @@ public class ChromecastSession {
      * @param textTrackStyle - The text track style
      * @param callback called with success or error
      */
-    public void loadMedia(String contentId, JSONObject customData, String contentType, long duration, String streamType, boolean autoPlay, double currentTime, JSONObject metadata, JSONObject textTrackStyle, CallbackContext callback) {
+    public void loadMedia(String contentId, JSONObject customData, String contentType, long duration, String streamType, boolean autoPlay, double currentTime, JSONObject metadata, JSONObject textTrackStyle, JSONArray tracks, CallbackContext callback) {
         if (client == null || session == null) {
             callback.error("session_error");
             return;
         }
         activity.runOnUiThread(new Runnable() {
             public void run() {
-                MediaInfo mediaInfo = ChromecastUtilities.createMediaInfo(contentId, customData, contentType, duration, streamType, metadata, textTrackStyle);
+                MediaInfo mediaInfo = ChromecastUtilities.createMediaInfo(contentId, customData, contentType, duration, streamType, metadata, textTrackStyle, tracks);
                 MediaLoadRequestData loadRequest = new MediaLoadRequestData.Builder()
                         .setMediaInfo(mediaInfo)
                         .setAutoplay(autoPlay)
@@ -267,6 +268,23 @@ public class ChromecastSession {
             public void run() {
                 client.play()
                         .setResultCallback(getResultCallback(callback, "Failed to play."));
+            }
+        });
+    }
+
+    /**
+     * Media API - Calls play on the current media.
+     * @param callback called with success or error
+     */
+    public void setPlayBackRate(Double playbackRate, CallbackContext callback) {
+        if (client == null || session == null) {
+            callback.error("session_error");
+            return;
+        }
+        activity.runOnUiThread(new Runnable() {
+            public void run() {
+                client.setPlaybackRate(playbackRate)
+                        .setResultCallback(getResultCallback(callback, "Failed to setPlaybackRate."));
             }
         });
     }

--- a/src/android/ChromecastSession.java
+++ b/src/android/ChromecastSession.java
@@ -276,14 +276,15 @@ public class ChromecastSession {
      * Media API - Calls play on the current media.
      * @param callback called with success or error
      */
-    public void setPlayBackRate(Double playbackRate, CallbackContext callback) {
+    public void setPlayBackRate(String playbackRate, CallbackContext callback) {
         if (client == null || session == null) {
             callback.error("session_error");
             return;
         }
         activity.runOnUiThread(new Runnable() {
             public void run() {
-                client.setPlaybackRate(playbackRate)
+                Double d = Double.valueOf(playbackRate);
+                client.setPlaybackRate(d)
                         .setResultCallback(getResultCallback(callback, "Failed to setPlaybackRate."));
             }
         });

--- a/src/android/ChromecastUtilities.java
+++ b/src/android/ChromecastUtilities.java
@@ -2,6 +2,7 @@ package acidhax.cordova.chromecast;
 
 import android.graphics.Color;
 import android.net.Uri;
+import java.util.ArrayList;
 
 import androidx.annotation.NonNull;
 import androidx.mediarouter.media.MediaRouter;
@@ -827,6 +828,7 @@ final class ChromecastUtilities {
         String streamType = "unknown";
         JSONObject metadata = new JSONObject();
         JSONObject textTrackStyle = new JSONObject();
+        JSONArray tracks = new JSONArray();
 
         // Try to get the actual values
         try {
@@ -858,10 +860,10 @@ final class ChromecastUtilities {
         } catch (JSONException e) {
         }
 
-        return createMediaInfo(contentId, customData, contentType, duration, streamType, metadata, textTrackStyle);
+        return createMediaInfo(contentId, customData, contentType, duration, streamType, metadata, textTrackStyle, tracks);
     }
 
-    static MediaInfo createMediaInfo(String contentId, JSONObject customData, String contentType, long duration, String streamType, JSONObject metadata, JSONObject textTrackStyle) {
+    static MediaInfo createMediaInfo(String contentId, JSONObject customData, String contentType, long duration, String streamType, JSONObject metadata, JSONObject textTrackStyle, JSONArray tracks) {
         MediaInfo.Builder mediaInfoBuilder = new MediaInfo.Builder(contentId);
 
         mediaInfoBuilder.setMetadata(createMediaMetadata(metadata));
@@ -886,6 +888,26 @@ final class ChromecastUtilities {
                 .setStreamType(intStreamType)
                 .setStreamDuration(duration)
                 .setTextTrackStyle(trackStyle);
+
+        if (tracks != null) {
+            List mediaTracks = new ArrayList();
+
+            for (int i = 0; i < tracks.length(); i++) {
+                try {
+                    JSONObject track = tracks.getJSONObject(i);
+                    MediaTrack mediaTrack = new MediaTrack.Builder(track.getInt("trackId"), MediaTrack.TYPE_TEXT)
+                        .setName(track.getString("name"))
+                        .setSubtype(MediaTrack.SUBTYPE_SUBTITLES)
+                        .setContentId(track.getString("trackContentId"))
+                        .setLanguage(track.getString("language"))
+                        .build();
+                    mediaTracks.add(mediaTrack);
+                } catch (JSONException e) {
+                }  
+            }
+
+            mediaInfoBuilder.setMediaTracks(mediaTracks);
+        }
 
         return mediaInfoBuilder.build();
     }

--- a/src/ios/MLPCastUtilities.h
+++ b/src/ios/MLPCastUtilities.h
@@ -9,7 +9,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MLPCastUtilities : NSObject
 
-+(GCKMediaInformation *)buildMediaInformation:(NSString *)contentUrl customData:(id )customData contentType:(NSString *)contentType duration:(double)duration streamType:(NSString *)streamType startTime:(double)startTime metaData:(NSDictionary *)metaData textTrackStyle:(NSDictionary *)textTrackStyle;
++(GCKMediaInformation *)buildMediaInformation:(NSString *)contentUrl customData:(id )customData contentType:(NSString *)contentType duration:(double)duration streamType:(NSString *)streamType startTime:(double)startTime metaData:(NSDictionary *)metaData textTrackStyle:(NSDictionary *)textTrackStyle tracks:(NSArray *)tracks;
 +(GCKMediaQueueItem *)buildMediaQueueItem:(NSDictionary *)item;
 + (GCKMediaTextTrackStyle *)buildTextTrackStyle:(NSDictionary *)data;
 +(GCKMediaMetadata*)buildMediaMetadata:(NSDictionary*)data;

--- a/src/ios/MLPCastUtilities.m
+++ b/src/ios/MLPCastUtilities.m
@@ -8,7 +8,7 @@
 
 NSDictionary* queueOrderIDsByItemId = nil;
 
-+ (GCKMediaInformation *)buildMediaInformation:(NSString *)contentUrl customData:(id )customData contentType:(NSString *)contentType duration:(double)duration streamType:(NSString *)streamType startTime:(double)startTime metaData:(NSDictionary *)metaData textTrackStyle:(NSDictionary *)textTrackStyle {
++ (GCKMediaInformation *)buildMediaInformation:(NSString *)contentUrl customData:(id )customData contentType:(NSString *)contentType duration:(double)duration streamType:(NSString *)streamType startTime:(double)startTime metaData:(NSDictionary *)metaData textTrackStyle:(NSDictionary *)textTrackStyle tracks:(NSArray *)tracks {
     NSURL* url = [NSURL URLWithString:contentUrl];
     
     GCKMediaInformationBuilder* mediaInfoBuilder = [[GCKMediaInformationBuilder alloc] initWithContentURL:url];
@@ -26,7 +26,23 @@ NSDictionary* queueOrderIDsByItemId = nil;
     mediaInfoBuilder.startAbsoluteTime = startTime;
     mediaInfoBuilder.metadata = [MLPCastUtilities buildMediaMetadata:metaData];
     mediaInfoBuilder.textTrackStyle = [MLPCastUtilities buildTextTrackStyle:textTrackStyle];
-    
+
+    if (tracks != (id)[NSNull null]) {
+        NSMutableArray<GCKMediaTrack*>* mediaTracks = [NSMutableArray new];
+        for (id track in tracks) {
+            GCKMediaTrack *mediaTrack = [[GCKMediaTrack alloc] initWithIdentifier:[track[@"trackId"] intValue]
+                                    contentIdentifier:track[@"trackContentId"]
+                                          contentType:track[@"trackContentType"]
+                                                 type:GCKMediaTrackTypeText
+                                          textSubtype:GCKMediaTextTrackSubtypeCaptions
+                                                 name:track[@"name"]
+                                         languageCode:track[@"language"]
+                                           customData:track[@"customData"]];
+            [mediaTracks addObject:mediaTrack];
+        }
+        mediaInfoBuilder.mediaTracks = mediaTracks;
+    }
+
     return [mediaInfoBuilder build];
 }
 
@@ -42,7 +58,7 @@ NSDictionary* queueOrderIDsByItemId = nil;
     queueItemBuilder.startTime = startTime;
     queueItemBuilder.preloadTime = [item[@"preloadTime"] doubleValue];
     
-    queueItemBuilder.mediaInformation = [MLPCastUtilities buildMediaInformation:media[@"contentId"] customData:media[@"customData"] contentType:media[@"contentType"] duration:duration streamType:media[@"streamType"] startTime:startTime metaData:media[@"metadata"] textTrackStyle:item[@"textTrackStyle"]];
+    queueItemBuilder.mediaInformation = [MLPCastUtilities buildMediaInformation:media[@"contentId"] customData:media[@"customData"] contentType:media[@"contentType"] duration:duration streamType:media[@"streamType"] startTime:startTime metaData:media[@"metadata"] textTrackStyle:item[@"textTrackStyle"] tracks:item[@"tracks"]];
     
     return [queueItemBuilder build];
 }
@@ -52,22 +68,21 @@ NSDictionary* queueOrderIDsByItemId = nil;
     GCKMediaTextTrackStyle* mediaTextTrackStyle = [GCKMediaTextTrackStyle createDefault];
     
     if (error == nil) {
-        NSString* bkgColor = data[@"backgroundColor"];
+        // Not working dictionary
+        // NSString* bkgColor = data[@"backgroundColor"];
+        NSString* bkgColor = @"#000000fa";
         if (bkgColor != nil) {
             mediaTextTrackStyle.backgroundColor = [[GCKColor alloc] initWithCSSString:bkgColor];
-            
         }
         
         NSObject* customData = data[@"customData"];
         if (bkgColor != nil) {
             mediaTextTrackStyle.customData = customData;
-            
         }
         
         NSString* edgeColor = data[@"edgeColor"];
         if (edgeColor != nil) {
             mediaTextTrackStyle.edgeColor = [[GCKColor alloc] initWithCSSString:edgeColor];
-            
         }
         
         NSString* edgeType = data[@"edgeType"];

--- a/src/ios/MLPChromecast.h
+++ b/src/ios/MLPChromecast.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)addMessageListener:(CDVInvokedUrlCommand*)command;
 - (void)sendMessage:(CDVInvokedUrlCommand*) command;
 - (void)mediaPlay:(CDVInvokedUrlCommand*)command;
-- (void)mediaPause:(CDVInvokedUrlCommand*)command;
+- (void)setMediaPlayBackRate:(CDVInvokedUrlCommand*)command;
 - (void)mediaSeek:(CDVInvokedUrlCommand*)command;
 - (void)mediaStop:(CDVInvokedUrlCommand*)command;
 - (void)mediaEditTracksInfo:(CDVInvokedUrlCommand*)command;

--- a/src/ios/MLPChromecast.m
+++ b/src/ios/MLPChromecast.m
@@ -267,7 +267,8 @@ int scansRunning = 0;
     double currentTime = [command.arguments[6] doubleValue];
     NSDictionary* metadata = command.arguments[7];
     NSDictionary* textTrackStyle = command.arguments[8];
-    GCKMediaInformation* mediaInfo = [MLPCastUtilities buildMediaInformation:contentId customData:customData contentType:contentType duration:duration streamType:streamType startTime:currentTime metaData:metadata textTrackStyle:textTrackStyle];
+    NSArray* tracks = command.arguments[9];
+    GCKMediaInformation* mediaInfo = [MLPCastUtilities buildMediaInformation:contentId customData:customData contentType:contentType duration:duration streamType:streamType startTime:currentTime metaData:metadata textTrackStyle:textTrackStyle tracks:tracks];
     
     [self.currentSession loadMediaWithCommand:command mediaInfo:mediaInfo autoPlay:autoplay currentTime:currentTime];
 }
@@ -288,6 +289,10 @@ int scansRunning = 0;
     [self.currentSession mediaPlayWithCommand:command];
 }
 
+- (void)setMediaPlayBackRate:(CDVInvokedUrlCommand*)command {
+    NSString* playbackRate = command.arguments[0];
+    [self.currentSession sendPlaybackRateWithCommand:command playbackRate:playbackRate];
+}
 - (void)mediaPause:(CDVInvokedUrlCommand*)command {
     [self.currentSession mediaPauseWithCommand:command];
 }
@@ -305,7 +310,7 @@ int scansRunning = 0;
 
 - (void)mediaEditTracksInfo:(CDVInvokedUrlCommand*)command {
     NSArray<NSNumber*>* activeTrackIds = command.arguments[0];
-    NSData* textTrackStyle = command.arguments[1];
+    NSDictionary* textTrackStyle = command.arguments[1];
     
     GCKMediaTextTrackStyle* textTrackStyleObject = [MLPCastUtilities buildTextTrackStyle:textTrackStyle];
     [self.currentSession setActiveTracksWithCommand:command activeTrackIds:activeTrackIds textTrackStyle:textTrackStyleObject];

--- a/src/ios/MLPChromecastSession.h
+++ b/src/ios/MLPChromecastSession.h
@@ -32,6 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)mediaSeekWithCommand:(CDVInvokedUrlCommand*)command position:(NSTimeInterval)position resumeState:(GCKMediaResumeState)resumeState;
 - (void)mediaPlayWithCommand:(CDVInvokedUrlCommand*)command;
 - (void)mediaPauseWithCommand:(CDVInvokedUrlCommand*)command;
+- (void)sendPlaybackRateWithCommand:(CDVInvokedUrlCommand*)command playbackRate:(NSString*)playbackRate;
 - (void)mediaStopWithCommand:(CDVInvokedUrlCommand*)command;
 - (void)setActiveTracksWithCommand:(CDVInvokedUrlCommand*)command activeTrackIds:(NSArray<NSNumber*>*)activeTrackIds textTrackStyle:(GCKMediaTextTrackStyle*)textTrackStyle;
 - (void)queueLoadItemsWithCommand:(CDVInvokedUrlCommand *)command queueItems:(NSArray *)queueItems startIndex:(NSInteger)startIndex repeatMode:(GCKMediaRepeatMode)repeatMode;

--- a/src/ios/MLPChromecastSession.m
+++ b/src/ios/MLPChromecastSession.m
@@ -263,6 +263,12 @@ NSMutableArray<MLPCastRequestDelegate*>* requestDelegates;
     request.delegate = [self createMediaUpdateRequestDelegate:command];
 }
 
+- (void)sendPlaybackRateWithCommand:(CDVInvokedUrlCommand*)command playbackRate:(NSString*)playbackRate {
+    float playbackRateFloat = [playbackRate floatValue];
+    GCKRequest* request = [self.remoteMediaClient setPlaybackRate:playbackRateFloat];
+    request.delegate = [self createMediaUpdateRequestDelegate:command];
+}
+
 - (void)mediaStopWithCommand:(CDVInvokedUrlCommand*)command {
     GCKRequest* request = [self.remoteMediaClient stop];
     request.delegate = [self createMediaUpdateRequestDelegate:command];

--- a/www/chrome.cast.js
+++ b/www/chrome.cast.js
@@ -725,7 +725,7 @@ chrome.cast.Session.prototype.loadMedia = function (loadRequest, successCallback
     var self = this;
 
     var mediaInfo = loadRequest.media;
-    execute('loadMedia', mediaInfo.contentId, mediaInfo.customData || {}, mediaInfo.contentType, mediaInfo.duration || 0.0, mediaInfo.streamType, loadRequest.autoplay || false, loadRequest.currentTime || 0, mediaInfo.metadata || {}, mediaInfo.textTrackSytle || {}, function (err, obj) {
+    execute('loadMedia', mediaInfo.contentId, mediaInfo.customData || {}, mediaInfo.contentType, mediaInfo.duration || 0.0, mediaInfo.streamType, loadRequest.autoplay || false, loadRequest.currentTime || 0, mediaInfo.metadata || {}, mediaInfo.textTrackSytle || {}, mediaInfo.tracks || null, function (err, obj) {
         if (!err) {
             self._loadNewMedia(obj);
             successCallback(self._getMedia());
@@ -1100,10 +1100,21 @@ chrome.cast.media.Media.prototype.play = function (playRequest, successCallback,
     });
 };
 
+chrome.cast.media.Media.prototype.setPlayBackRate = function (playBackRate, successCallback, errorCallback) {
+    if (this._preCheck(errorCallback)) { return; }
+    execute('setMediaPlayBackRate', playBackRate, function (err) {
+        if (!err) {
+            successCallback && successCallback();
+        } else {
+            handleError(err, errorCallback);
+        }
+    });
+};
+
 /**
  * Pauses the media item.
  * @param  {chrome.cast.media.PauseRequest} pauseRequest     The optional media pause request.
- * @param  {function}                         successCallback Invoked on success.
+ * @param  {function}                      \   successCallback Invoked on success.
  * @param  {function}                         errorCallback   Invoked on error. The possible errors are TIMEOUT, API_NOT_INITIALIZED, INVALID_PARAMETER, CHANNEL_ERROR, SESSION_ERROR, and EXTENSION_MISSING.
  */
 chrome.cast.media.Media.prototype.pause = function (pauseRequest, successCallback, errorCallback) {


### PR DESCRIPTION
### Platforms affected
Android


### Motivation and Context
possibility of accelerating videos on android, and viewing subtitles with setMediaTracks



### Description
Possibility to change the playbackrate of the video on android, and visualization of subtitles with setMediaTracks. If possible do the same on IOS, I am not IOS developer


### Testing
emulator, real device and chromecast



### Checklist
- [ ] I've updated the documentation as necessary
- [ ] If this Pull Request resolves an issue, I linked to the issue in the text above (and used the correct [keyword to close issues using keywords](https://help.github.com/articles/closing-issues-using-keywords/))
- [x ] I've run `npm test` and no errors were found (run `npm style` to auto-fix errors it can)
- [ x] I've run the tests (See Readme)
- [ ] I added automated test coverage as appropriate for this change (See Readme Contributing section)